### PR TITLE
Require `php-64bit` for the SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "absmartly/php-sdk",
     "type": "library",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php-64bit": "^7.4 || ^8.0",
         "lastguest/murmurhash": "~2.1.1",
         "ext-curl": "*",
         "ext-json": "*"


### PR DESCRIPTION
Because `PublishEvent` requires milisecond-level precision, and expects an `int`, we have to require PHP 64 bit builds to prevent overflows.